### PR TITLE
Add lambda for Costco price notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # costco-price-watcher
-コストコの価格をウォッチして、指定価格より下がっていたらLINEに通知するLambda
+
+AWS Lambda function that watches Costco product pages and sends a LINE notification when a price drops below a configured threshold.
+
+## Environment variables
+
+- `TARGETS` – JSON array of objects containing `url` and `threshold` keys. Example:
+  ```json
+  [
+    {"url": "https://www.costco.co.jp/Example-Item", "threshold": 2000},
+    {"url": "https://www.costco.co.jp/Another", "threshold": 1500}
+  ]
+  ```
+- `LINE_TOKEN` – Channel access token for the LINE Messaging API.
+- `LINE_USER_ID` – User ID to send notifications to.
+
+## Handler
+
+The Lambda entry point is `lambda_function.lambda_handler`.
+
+## Development
+
+Tests can be run with:
+
+```bash
+pytest
+```

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,0 +1,63 @@
+import os
+import json
+import re
+from urllib.request import Request, urlopen
+
+PRICE_RE = re.compile(r"¥([\d,]+)")
+
+
+def fetch_page(url: str) -> str:
+    with urlopen(url) as resp:
+        return resp.read().decode("utf-8")
+
+
+def extract_price(html: str) -> int:
+    match = PRICE_RE.search(html)
+    if not match:
+        raise ValueError("Price not found")
+    price_str = match.group(1).replace(",", "")
+    return int(price_str)
+
+
+def send_line_message(token: str, user_id: str, message: str) -> None:
+    payload = json.dumps({
+        "to": user_id,
+        "messages": [{"type": "text", "text": message}]
+    }).encode("utf-8")
+    req = Request(
+        "https://api.line.me/v2/bot/message/push",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json"
+        }
+    )
+    with urlopen(req) as resp:
+        resp.read()
+
+
+def lambda_handler(event, context):
+    targets_env = os.environ.get("TARGETS")
+    line_token = os.environ.get("LINE_TOKEN")
+    user_id = os.environ.get("LINE_USER_ID")
+    if not targets_env or not line_token or not user_id:
+        raise ValueError(
+            "TARGETS, LINE_TOKEN and LINE_USER_ID env vars are required"
+        )
+
+    targets = json.loads(targets_env)
+    results = []
+    for item in targets:
+        url = item["url"]
+        threshold = int(item["threshold"])
+        html = fetch_page(url)
+        price = extract_price(html)
+        if price <= threshold:
+            message = (
+                f"{url} の価格が {price} 円になりました (指定価格 {threshold} 円)"
+            )
+            send_line_message(line_token, user_id, message)
+            results.append({"url": url, "price": price, "notified": True})
+        else:
+            results.append({"url": url, "price": price, "notified": False})
+    return {"results": results}

--- a/tests/test_extract_price.py
+++ b/tests/test_extract_price.py
@@ -1,0 +1,6 @@
+from lambda_function import extract_price
+
+HTML = '<span class="product-price-amount"><span class="notranslate">¥1,848</span></span>'
+
+def test_extract_price():
+    assert extract_price(HTML) == 1848

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,0 +1,25 @@
+import json
+import builtins
+from lambda_function import lambda_handler
+
+class DummyResponse:
+    def __init__(self, data):
+        self.data = data.encode('utf-8')
+    def read(self):
+        return self.data
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+def test_lambda_handler(monkeypatch):
+    html = '<span class="notranslate">¥1,000</span>'
+    def fake_urlopen(req, *args, **kwargs):
+        return DummyResponse(html)
+    monkeypatch.setattr('lambda_function.urlopen', fake_urlopen)
+    targets = [{'url': 'http://example.com', 'threshold': 2000}]
+    monkeypatch.setitem(lambda_handler.__globals__['os'].environ, 'TARGETS', json.dumps(targets))
+    monkeypatch.setitem(lambda_handler.__globals__['os'].environ, 'LINE_TOKEN', 'dummy')
+    monkeypatch.setitem(lambda_handler.__globals__['os'].environ, 'LINE_USER_ID', 'U1234567890')
+    result = lambda_handler({}, {})
+    assert result['results'][0]['notified']


### PR DESCRIPTION
## Summary
- switch from LINE Notify to LINE Messaging API
- update README with new env vars
- adapt lambda function and tests to use user ID

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683d951a4358832dbe66d1c4e915580f