### PR TITLE
Use Costco API for price checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ AWS Lambda function that watches Costco product pages and sends a LINE notificat
 
 ## Environment variables
 
-- `TARGETS` – JSON array of objects containing `url` and `threshold` keys. Example:
+- `TARGETS` – JSON array of objects containing `productCode` and `threshold` keys. Example:
   ```json
   [
-    {"url": "https://www.costco.co.jp/Example-Item", "threshold": 2000},
-    {"url": "https://www.costco.co.jp/Another", "threshold": 1500}
+    {"productCode": "74333", "threshold": 2000},
+    {"productCode": "12345", "threshold": 1500}
   ]
   ```
 - `LINE_TOKEN` – Channel access token for the LINE Messaging API.

--- a/tests/test_extract_price.py
+++ b/tests/test_extract_price.py
@@ -1,6 +1,7 @@
 from lambda_function import extract_price
 
-HTML = '<span class="product-price-amount"><span class="notranslate">¥1,848</span></span>'
+DATA = {"schemaOrgProduct": '{"offers": {"price": "1848.0"}}'}
+
 
 def test_extract_price():
-    assert extract_price(HTML) == 1848
+    assert extract_price(DATA) == 1848

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -13,12 +13,18 @@ class DummyResponse:
         pass
 
 def test_lambda_handler(monkeypatch):
-    html = '<span class="notranslate">¥1,000</span>'
+    data = {"schemaOrgProduct": '{"offers": {"price": "1000.0"}}'}
+
     def fake_urlopen(req, *args, **kwargs):
-        return DummyResponse(html)
+        return DummyResponse(json.dumps(data))
+
     monkeypatch.setattr('lambda_function.urlopen', fake_urlopen)
-    targets = [{'url': 'http://example.com', 'threshold': 2000}]
-    monkeypatch.setitem(lambda_handler.__globals__['os'].environ, 'TARGETS', json.dumps(targets))
+    targets = [{'productCode': '12345', 'threshold': 2000}]
+    monkeypatch.setitem(
+        lambda_handler.__globals__['os'].environ,
+        'TARGETS',
+        json.dumps(targets)
+    )
     monkeypatch.setitem(lambda_handler.__globals__['os'].environ, 'LINE_TOKEN', 'dummy')
     monkeypatch.setitem(lambda_handler.__globals__['os'].environ, 'LINE_USER_ID', 'U1234567890')
     result = lambda_handler({}, {})


### PR DESCRIPTION
## Summary
- fetch product details from Costco API instead of scraping HTML
- parse price from API response
- update notification formatting to use thousands separator
- expect `TARGETS` to provide `productCode`
- update tests and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68561e5a1f8c832d8f42f5f4a2aa70ca