### PR TITLE
Use product name for logs and notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # costco-price-watcher
 
-AWS Lambda function that watches Costco product pages and sends a LINE notification when a price drops below a configured threshold.
+AWS Lambda function that watches Costco product pages and sends a LINE notification when a price drops below a configured threshold. The notification message includes the product name taken from the API's `metaTitle` field.
 
 ## Environment variables
 

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -13,12 +13,22 @@ class DummyResponse:
         pass
 
 def test_lambda_handler(monkeypatch):
-    data = {"schemaOrgProduct": '{"offers": {"price": "1000.0"}}'}
+    data = {
+        "metaTitle": "テスト商品",
+        "schemaOrgProduct": '{"offers": {"price": "1000.0"}}'
+    }
 
     def fake_urlopen(req, *args, **kwargs):
         return DummyResponse(json.dumps(data))
 
     monkeypatch.setattr('lambda_function.urlopen', fake_urlopen)
+
+    sent_messages = []
+
+    def fake_send_line_message(token, user_id, message):
+        sent_messages.append(message)
+
+    monkeypatch.setattr('lambda_function.send_line_message', fake_send_line_message)
     targets = [{'productCode': '12345', 'threshold': 2000}]
     monkeypatch.setitem(
         lambda_handler.__globals__['os'].environ,
@@ -29,3 +39,4 @@ def test_lambda_handler(monkeypatch):
     monkeypatch.setitem(lambda_handler.__globals__['os'].environ, 'LINE_USER_ID', 'U1234567890')
     result = lambda_handler({}, {})
     assert result['results'][0]['notified']
+    assert 'テスト商品' in sent_messages[0]


### PR DESCRIPTION
## Summary
- display product names in notifications and logs using `metaTitle`
- include product name in results
- capture notification messages in test to verify name usage
- note metaTitle usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68561f783b74832da5d41e964bd3aa3c