### PR TITLE
Include product URL in LINE notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # costco-price-watcher
 
-AWS Lambda function that watches Costco product pages and sends a LINE notification when a price drops below a configured threshold. The notification message includes the product name taken from the API's `metaTitle` field.
+AWS Lambda function that watches Costco product pages and sends a LINE notification when a price drops below a configured threshold. The notification message includes the product name taken from the API's `metaTitle` field and the product URL extracted from the API response.
 
 ## Environment variables
 

--- a/tests/test_extract_price.py
+++ b/tests/test_extract_price.py
@@ -1,7 +1,11 @@
-from lambda_function import extract_price
+from lambda_function import extract_price, extract_product_url
 
-DATA = {"schemaOrgProduct": '{"offers": {"price": "1848.0"}}'}
+DATA = {"schemaOrgProduct": '{"offers": {"price": "1848.0", "url": "https://example.com/product"}}'}
 
 
 def test_extract_price():
     assert extract_price(DATA) == 1848
+
+
+def test_extract_product_url():
+    assert extract_product_url(DATA) == "https://example.com/product"

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -15,7 +15,7 @@ class DummyResponse:
 def test_lambda_handler(monkeypatch):
     data = {
         "metaTitle": "テスト商品",
-        "schemaOrgProduct": '{"offers": {"price": "1000.0"}}'
+        "schemaOrgProduct": '{"offers": {"price": "1000.0", "url": "https://example.com/product"}}'
     }
 
     def fake_urlopen(req, *args, **kwargs):
@@ -40,3 +40,4 @@ def test_lambda_handler(monkeypatch):
     result = lambda_handler({}, {})
     assert result['results'][0]['notified']
     assert 'テスト商品' in sent_messages[0]
+    assert 'https://example.com/product' in sent_messages[0]


### PR DESCRIPTION
## Summary
- add function to extract product URL from metadata
- include product URL in notification message and results
- update README for new behavior
- extend unit tests for URL extraction and message content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856223b5bc0832da2e28b77711380c3